### PR TITLE
proton: complete PROTON_NATIVE_STEAM so a real Windows Steam survives

### DIFF
--- a/proton
+++ b/proton
@@ -1083,23 +1083,31 @@ class CompatData:
                 #copy steam files into place
                 steam_dir = "drive_c/Program Files (x86)/Steam/"
                 makedirs(self.prefix_dir + steam_dir)
-                filestocopy = [("steamclient.dll", "steamclient.dll"),
-                               ("steamclient64.dll", "steamclient64.dll"),
-                               ("GameOverlayRenderer64.dll", "GameOverlayRenderer64.dll"),
-                               ("SteamService.exe", "steam.exe"),
-                               ("Steam.dll", "Steam.dll")]
-                for (src,tgt) in filestocopy:
-                    srcfile = steamdir + '/legacycompat/' + src
-                    if os.path.isfile(srcfile):
-                        try_copy(srcfile, steam_dir + tgt, prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
+                # With PROTON_NATIVE_STEAM the prefix holds a real Windows Steam
+                # install, and these copies would overwrite it. In particular
+                # SteamService.exe is copied over steam.exe, replacing the genuine
+                # bootstrap with a binary that only prints a usage message and
+                # exits 1 -- on every launch, so the install never survives.
+                if os.environ.get("PROTON_NATIVE_STEAM", "0") == "1":
+                    log("PROTON_NATIVE_STEAM: keeping the existing Steam install in the prefix")
+                else:
+                    filestocopy = [("steamclient.dll", "steamclient.dll"),
+                                   ("steamclient64.dll", "steamclient64.dll"),
+                                   ("GameOverlayRenderer64.dll", "GameOverlayRenderer64.dll"),
+                                   ("SteamService.exe", "steam.exe"),
+                                   ("Steam.dll", "Steam.dll")]
+                    for (src,tgt) in filestocopy:
+                        srcfile = steamdir + '/legacycompat/' + src
+                        if os.path.isfile(srcfile):
+                            try_copy(srcfile, steam_dir + tgt, prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
 
-                filestocopy = [("steamclient64.dll", "steamclient64.dll"),
-                               ("GameOverlayRenderer.dll", "GameOverlayRenderer.dll"),
-                               ("GameOverlayRenderer64.dll", "GameOverlayRenderer64.dll")]
-                for (src,tgt) in filestocopy:
-                    srcfile = g_proton.path(src)
-                    if os.path.isfile(srcfile):
-                        try_copy(srcfile, steam_dir + tgt, prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
+                    filestocopy = [("steamclient64.dll", "steamclient64.dll"),
+                                   ("GameOverlayRenderer.dll", "GameOverlayRenderer.dll"),
+                                   ("GameOverlayRenderer64.dll", "GameOverlayRenderer64.dll")]
+                    for (src,tgt) in filestocopy:
+                        srcfile = g_proton.path(src)
+                        if os.path.isfile(srcfile):
+                            try_copy(srcfile, steam_dir + tgt, prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
 
                 # CW Bug 19152. IL-2 Sturmovik: Cliffs of Dover Blitz Edition needs user's localconfig.vdf
                 if os.environ.get("SteamGameId", 0) == "754530":
@@ -2354,7 +2362,12 @@ class Session:
         return subprocess.call(args, env=local_env, stderr=self.log_file, stdout=self.log_file)
 
     def run(self):
-        if shutil.which('steam-runtime-launcher-interface-0') is not None:
+        # The launcher-interface adverb registers the launched process with the
+        # running Steam client. When the thing being launched is itself a Steam
+        # client, that hands it off to the native one and it exits.
+        if os.environ.get("PROTON_NATIVE_STEAM", "0") == "1":
+            adverb = []
+        elif shutil.which('steam-runtime-launcher-interface-0') is not None:
             adverb = ['steam-runtime-launcher-interface-0', 'proton']
         else:
             adverb = []
@@ -2395,7 +2408,13 @@ class Session:
         else:
             if "UMU_ID" in os.environ:
                 append_to_env_str(self.env, "WINEDLLOVERRIDES", "lsteamclient=d", ";")
-            if g_proton.host_pe_arch == "x86_64-windows":
+            # The builtin stub forwards to the native Steam client and exits,
+            # which starts a second Steam instead of running the real Windows
+            # steam.exe. Invoke wine directly so the requested binary runs.
+            if os.environ.get("PROTON_NATIVE_STEAM", "0") == "1":
+                log("PROTON_NATIVE_STEAM: bypassing the builtin steam.exe stub")
+                argv = [g_proton.wine_bin]
+            elif g_proton.host_pe_arch == "x86_64-windows":
                 #run with winepreloader directly to avoid restart through start.exe
                 self.env["WINELOADERNOEXEC"] = "1"
                 argv = [g_proton.lib_dir + "/wine/x86_64-unix/wine-preloader", g_proton.lib_dir + "/wine/x86_64-unix/wine", "c:\\windows\\system32\\steam.exe"]


### PR DESCRIPTION
### Summary

`PROTON_NATIVE_STEAM` already exists here and does one thing: it stops the built-in `steam.exe` wrapper from hijacking a real `steam.exe`, and disables lsteamclient. But three other paths still assume the prefix contains Proton's own Steam stubs rather than a genuine Windows Steam install, so the intent of the variable isn't actually reachable yet. This completes it.

Every change is behind the existing variable — **behavior is unchanged unless `PROTON_NATIVE_STEAM=1`**.

### The three paths

**1. `setup_prefix()` overwrites the real client.** It copies `SteamService.exe` over `drive_c/Program Files (x86)/Steam/steam.exe`, replacing the genuine ~5.7 MB bootstrap with a ~2.8 MB binary that only prints `Usage: steamservice.exe /command` and exits 1. It runs on *every* launch, so an install can never survive one. Every "Steam won't start" / "can't connect to the Steam network" symptom in this configuration traced back to this single copy.

**2. `run()` applies the launcher-interface adverb.** `steam-runtime-launcher-interface-0` registers the launched process with the *running* Steam client. When the thing being launched is itself a Steam client, that hands it off to the native one and the new client exits.

**3. The launch path routes through the built-in stub.** `c:\windows\system32\steam.exe` forwards to the native client and exits, starting a second Steam instead of running the Windows `steam.exe` that was requested. With the variable set, wine is invoked directly.

### Why

Running a real Windows Steam client inside a prefix is the only way to get the *Windows* Steam overlay over Proton-run games — the native overlay can't composite into them in some configurations, and one Steam account can only hold one session, so a "native client for the library, Windows client for the overlay" split isn't possible. With these three fixes, a Windows Steam client installs, updates, stays logged in, and launches games from inside the prefix.

Note this does not *install* Windows Steam — it only stops Proton from destroying or bypassing an install that is already there.

### Testing

Used continuously as a daily driver on a prefix with a real Windows Steam client: sign-in, client self-update, library, and launching titles across D3D9, DXVK (D3D11), vkd3d-proton (D3D12) and native Vulkan. Verified that with the variable unset, the script's behavior is byte-identical to before, and that applying the patch to a pristine tree and re-running it is a no-op.

### Implementation
Via [proton-native-steam-completion.patch](https://github.com/user-attachments/files/30862966/proton-native-steam-completion.patch)